### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -8,7 +8,7 @@
   },
   "author": {
     "name": "CERN",
-    "email": "info@invenio-software.org"
+    "email": "info@inveniosoftware.org"
   },
   "license": "GPLv2",
   "private": "true",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Invenio JS for uploading files",
   "author": {
     "name": "CERN",
-    "email": "info@invenio-software.org"
+    "email": "info@inveniosoftware.org"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>